### PR TITLE
Fix conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ StatusWord, and DataWord.
 
     let message = Message::new()
         .with_command(CommandWord::new()
-            .with_address(12)
-            .with_subaddress(5)
+            .with_address(Address::Value(12))
+            .with_subaddress(SubAddress::Value(5))
             .with_word_count(2)
             .build().unwrap()
         ).unwrap()

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-chain_width = 40
+chain_width = 60

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-chain_width = 30
+chain_width = 40

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 //! Error enums and flags
 
-use core::array::TryFromSliceError;
+use core::{array::TryFromSliceError, str::Utf8Error};
 
 /// A result type which uses the [Error] enum as the error type.
 pub type Result<T> = core::result::Result<T, Error>;
@@ -79,6 +79,12 @@ pub enum Error {
 
 impl From<TryFromSliceError> for Error {
     fn from(_: TryFromSliceError) -> Self {
+        Self::FromSliceError
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(_: Utf8Error) -> Self {
         Self::FromSliceError
     }
 }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -143,7 +143,8 @@ pub(crate) const STATUS_SUBSYSTEM_ERROR_FIELD: Field = Field::from(STATUS_SUBSYS
 pub(crate) const STATUS_DYNAMIC_BUS_ACCEPTANCE: u16 = 0b0000000000000010;
 
 /// Field definition for the bus control accept flag of the status word.
-pub(crate) const STATUS_DYNAMIC_BUS_ACCEPTANCE_FIELD: Field = Field::from(STATUS_DYNAMIC_BUS_ACCEPTANCE);
+pub(crate) const STATUS_DYNAMIC_BUS_ACCEPTANCE_FIELD: Field =
+    Field::from(STATUS_DYNAMIC_BUS_ACCEPTANCE);
 
 /// Mask for parsing the terminal flag of the status word.
 pub(crate) const STATUS_TERMINAL_ERROR: u16 = 0b0000000000000001;

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,5 +1,7 @@
 //! Fields found in command and status words
 
+use crate::Word;
+
 /// Represents a field inside of a 16-bit word
 ///
 /// Given a mask and offset, the Field struct can get
@@ -14,112 +16,137 @@ pub(crate) struct Field {
 }
 
 impl Field {
-    /// Create a new field given a mask
-    pub(crate) const fn new(mask: u16) -> Self {
-        Self {
-            mask,
-            offset: mask.trailing_zeros(),
-        }
+    /// Create a new field
+    pub(crate) const fn new() -> Self {
+        Self { mask: 0, offset: 0 }
+    }
+
+    /// Constructor method to add a mask to the field
+    pub(crate) const fn with_mask(mut self, mask: u16) -> Self {
+        self.mask = mask;
+        self
+    }
+
+    /// Constructor method to set an offset explicitly
+    pub(crate) const fn with_offset(mut self, offset: u32) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    /// Constructor method to calculate an offset
+    pub(crate) const fn with_calculated_offset(mut self) -> Self {
+        self.offset = self.mask.trailing_zeros();
+        self
+    }
+
+    /// Create a new field from a mask
+    pub(crate) const fn from(mask: u16) -> Self {
+        Self::new()
+            .with_mask(mask)
+            .with_offset(0)
+            .with_calculated_offset()
     }
 
     /// Read the value of the field from a data word
-    pub(crate) const fn get(&self, data: u16) -> u8 {
-        ((data & self.mask) >> self.offset) as u8
+    pub(crate) fn get<T: Word>(&self, word: &T) -> u8 {
+        let value = word.as_value() & self.mask;
+        (value >> self.offset) as u8
     }
 
     /// Write the value of the field to a data word
-    pub(crate) const fn set(&self, data: u16, value: u8) -> u16 {
-        let v = (value as u16) << self.offset;
-        (data & !self.mask) | (v & self.mask)
+    pub(crate) fn set<T: Word>(&self, word: &mut T, value: u8) {
+        let value = (value as u16) << self.offset;
+        let data = word.as_value() & !self.mask;
+        word.set_value(data | (value & self.mask));
     }
 }
 
 /// Mask for parsing the terminal address of a command word.
-pub(crate) const COMMAND_TERMINAL_ADDRESS: u16 = 0b1111100000000000;
+pub(crate) const COMMAND_ADDRESS: u16 = 0b1111100000000000;
 
 /// Field definition for the terminal address of a command word.
-pub(crate) const COMMAND_TERMINAL_ADDRESS_FIELD: Field = Field::new(COMMAND_TERMINAL_ADDRESS);
+pub(crate) const COMMAND_ADDRESS_FIELD: Field = Field::from(COMMAND_ADDRESS);
 
 /// Mask for parsing the transmit/receive flag of a command word.
 pub(crate) const COMMAND_TRANSMIT_RECEIVE: u16 = 0b0000010000000000;
 
 /// Field definition for the transmit/receive flag of a command word.
-pub(crate) const COMMAND_TRANSMIT_RECEIVE_FIELD: Field = Field::new(COMMAND_TRANSMIT_RECEIVE);
+pub(crate) const COMMAND_TRANSMIT_RECEIVE_FIELD: Field = Field::from(COMMAND_TRANSMIT_RECEIVE);
 
 /// Mask for parsing the terminal subaddress of a command word.
 pub(crate) const COMMAND_SUBADDRESS: u16 = 0b0000001111100000;
 
 /// Field definition for the terminal subaddress of a command word.
-pub(crate) const COMMAND_SUBADDRESS_FIELD: Field = Field::new(COMMAND_SUBADDRESS);
+pub(crate) const COMMAND_SUBADDRESS_FIELD: Field = Field::from(COMMAND_SUBADDRESS);
 
 /// Mask for parsing the mode code of a command word.
 pub(crate) const COMMAND_MODE_CODE: u16 = 0b0000000000011111;
 
 /// Field definition for the mode code of a command word.
-pub(crate) const COMMAND_MODE_CODE_FIELD: Field = Field::new(COMMAND_MODE_CODE);
+pub(crate) const COMMAND_MODE_CODE_FIELD: Field = Field::from(COMMAND_MODE_CODE);
 
 /// Mask for parsing the word count of a command word.
 pub(crate) const COMMAND_WORD_COUNT: u16 = 0b0000000000011111;
 
 /// Field definition for the word count of a command word.
-pub(crate) const COMMAND_WORD_COUNT_FIELD: Field = Field::new(COMMAND_WORD_COUNT);
+pub(crate) const COMMAND_WORD_COUNT_FIELD: Field = Field::from(COMMAND_WORD_COUNT);
 
 /// Mask for parsing the terminal address of a status word.
-pub(crate) const STATUS_TERMINAL_ADDRESS: u16 = 0b1111100000000000;
+pub(crate) const STATUS_ADDRESS: u16 = 0b1111100000000000;
 
 /// Field definition for the terminal address of a status word.
-pub(crate) const STATUS_TERMINAL_ADDRESS_FIELD: Field = Field::new(STATUS_TERMINAL_ADDRESS);
+pub(crate) const STATUS_ADDRESS_FIELD: Field = Field::from(STATUS_ADDRESS);
 
 /// Mask for parsing the error flag of a status word.
 pub(crate) const STATUS_MESSAGE_ERROR: u16 = 0b0000010000000000;
 
 /// Field definition for the error flag of a status word.
-pub(crate) const STATUS_MESSAGE_ERROR_FIELD: Field = Field::new(STATUS_MESSAGE_ERROR);
+pub(crate) const STATUS_MESSAGE_ERROR_FIELD: Field = Field::from(STATUS_MESSAGE_ERROR);
 
 /// Mask for parsing the instrumentation flag of a status word.
 pub(crate) const STATUS_INSTRUMENTATION: u16 = 0b0000001000000000;
 
 /// Field definition for the instrumentation flag of a status word.
-pub(crate) const STATUS_INSTRUMENTATION_FIELD: Field = Field::new(STATUS_INSTRUMENTATION);
+pub(crate) const STATUS_INSTRUMENTATION_FIELD: Field = Field::from(STATUS_INSTRUMENTATION);
 
 /// Mask for parsing the service request flag of a status word.
 pub(crate) const STATUS_SERVICE_REQUEST: u16 = 0b0000000100000000;
 
 /// Field definition for the service request flag of a status word.
-pub(crate) const STATUS_SERVICE_REQUEST_FIELD: Field = Field::new(STATUS_SERVICE_REQUEST);
+pub(crate) const STATUS_SERVICE_REQUEST_FIELD: Field = Field::from(STATUS_SERVICE_REQUEST);
 
 /// Mask for parsing the reserved bits of a status word.
-pub(crate) const STATUS_RESERVED_BITS: u16 = 0b0000000011100000;
+pub(crate) const STATUS_RESERVED: u16 = 0b0000000011100000;
 
 /// Field definition for the reserved bits of a status word.
-pub(crate) const STATUS_RESERVED_BITS_FIELD: Field = Field::new(STATUS_RESERVED_BITS);
+pub(crate) const STATUS_RESERVED_FIELD: Field = Field::from(STATUS_RESERVED);
 
 /// Mask for parsing the broadcast received flag of a status word.
 pub(crate) const STATUS_BROADCAST_RECEIVED: u16 = 0b0000000000010000;
 
 /// Field definition for the broadcast received flag of a status word.
-pub(crate) const STATUS_BROADCAST_RECEIVED_FIELD: Field = Field::new(STATUS_BROADCAST_RECEIVED);
+pub(crate) const STATUS_BROADCAST_RECEIVED_FIELD: Field = Field::from(STATUS_BROADCAST_RECEIVED);
 
 /// Mask for parsing the busy flag of the status word.
 pub(crate) const STATUS_TERMINAL_BUSY: u16 = 0b0000000000001000;
 
 /// Field definition for the busy flag of the status word.
-pub(crate) const STATUS_TERMINAL_BUSY_FIELD: Field = Field::new(STATUS_TERMINAL_BUSY);
+pub(crate) const STATUS_TERMINAL_BUSY_FIELD: Field = Field::from(STATUS_TERMINAL_BUSY);
 
 /// Mask for parsing the subsystem flag of the status word.
-pub(crate) const STATUS_SUBSYSTEM_FLAG: u16 = 0b0000000000000100;
+pub(crate) const STATUS_SUBSYSTEM_ERROR: u16 = 0b0000000000000100;
 
 /// Field definition for the subsystem flag of the status word.
-pub(crate) const STATUS_SUBSYSTEM_FLAG_FIELD: Field = Field::new(STATUS_SUBSYSTEM_FLAG);
+pub(crate) const STATUS_SUBSYSTEM_ERROR_FIELD: Field = Field::from(STATUS_SUBSYSTEM_ERROR);
 
 /// Mask for parsing the bus control accept flag of the status word.
-pub(crate) const STATUS_DYNAMIC_BUS_ACCEPT: u16 = 0b0000000000000010;
+pub(crate) const STATUS_DYNAMIC_BUS_ACCEPTANCE: u16 = 0b0000000000000010;
 
 /// Field definition for the bus control accept flag of the status word.
-pub(crate) const STATUS_DYNAMIC_BUS_ACCEPT_FIELD: Field = Field::new(STATUS_DYNAMIC_BUS_ACCEPT);
+pub(crate) const STATUS_DYNAMIC_BUS_ACCEPTANCE_FIELD: Field = Field::from(STATUS_DYNAMIC_BUS_ACCEPTANCE);
 
 /// Mask for parsing the terminal flag of the status word.
-pub(crate) const STATUS_TERMINAL_FLAG: u16 = 0b0000000000000001;
+pub(crate) const STATUS_TERMINAL_ERROR: u16 = 0b0000000000000001;
 
 /// Field definition for the terminal flag of the status word.
-pub(crate) const STATUS_TERMINAL_FLAG_FIELD: Field = Field::new(STATUS_TERMINAL_FLAG);
+pub(crate) const STATUS_TERMINAL_ERROR_FIELD: Field = Field::from(STATUS_TERMINAL_ERROR);

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -34,10 +34,6 @@ impl Field {
     }
 }
 
-/// Mask for an empty field
-#[cfg(test)]
-pub(crate) const WORD_EMPTY: u16 = 0b0000000000000000;
-
 /// Mask for parsing the terminal address of a command word.
 pub(crate) const COMMAND_TERMINAL_ADDRESS: u16 = 0b1111100000000000;
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -615,7 +615,7 @@ impl From<Reserved> for u8 {
 /// [^1]: [MIL-STD-1553 Tutorial](http://www.horntech.cn/techDocuments/MIL-STD-1553Tutorial.pdf)
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(u8)]
-pub enum BroadcastCommand {
+pub enum BroadcastReceived {
     /// This terminal has not received a broadcast command
     NotReceived = 0,
 
@@ -623,7 +623,7 @@ pub enum BroadcastCommand {
     Received = 1,
 }
 
-impl BroadcastCommand {
+impl BroadcastReceived {
     /// Check if enum is the NotReceived variant
     #[must_use = "Returned value is not used"]
     pub const fn is_notreceived(&self) -> bool {
@@ -637,7 +637,7 @@ impl BroadcastCommand {
     }
 }
 
-impl From<u8> for BroadcastCommand {
+impl From<u8> for BroadcastReceived {
     fn from(value: u8) -> Self {
         match value {
             1 => Self::Received,
@@ -646,11 +646,11 @@ impl From<u8> for BroadcastCommand {
     }
 }
 
-impl From<BroadcastCommand> for u8 {
-    fn from(value: BroadcastCommand) -> Self {
+impl From<BroadcastReceived> for u8 {
+    fn from(value: BroadcastReceived) -> Self {
         match value {
-            BroadcastCommand::Received => 1,
-            BroadcastCommand::NotReceived => 0,
+            BroadcastReceived::Received => 1,
+            BroadcastReceived::NotReceived => 0,
         }
     }
 }
@@ -722,7 +722,7 @@ impl From<TerminalBusy> for u8 {
 /// [^1]: [MIL-STD-1553 Tutorial](http://www.horntech.cn/techDocuments/MIL-STD-1553Tutorial.pdf)
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(u8)]
-pub enum BusControlAccept {
+pub enum DynamicBusAcceptance {
     /// This terminal has refused control of the bus
     NotAccepted = 0,
 
@@ -730,7 +730,7 @@ pub enum BusControlAccept {
     Accepted = 1,
 }
 
-impl BusControlAccept {
+impl DynamicBusAcceptance {
     /// Check if the enum is the NotAccepted variant
     #[must_use = "Returned value is not used"]
     pub const fn is_notaccepted(&self) -> bool {
@@ -744,7 +744,7 @@ impl BusControlAccept {
     }
 }
 
-impl From<u8> for BusControlAccept {
+impl From<u8> for DynamicBusAcceptance {
     fn from(value: u8) -> Self {
         match value {
             1 => Self::Accepted,
@@ -753,11 +753,11 @@ impl From<u8> for BusControlAccept {
     }
 }
 
-impl From<BusControlAccept> for u8 {
-    fn from(value: BusControlAccept) -> Self {
+impl From<DynamicBusAcceptance> for u8 {
+    fn from(value: DynamicBusAcceptance) -> Self {
         match value {
-            BusControlAccept::Accepted => 1,
-            BusControlAccept::NotAccepted => 0,
+            DynamicBusAcceptance::Accepted => 1,
+            DynamicBusAcceptance::NotAccepted => 0,
         }
     }
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -2,7 +2,7 @@
 
 macro_rules! fit {
     ( $v: expr, $p: expr ) => {
-        ($v & $p) > 0
+        $v <= $p
     };
 }
 
@@ -759,5 +759,24 @@ impl From<BusControlAccept> for u8 {
             BusControlAccept::Accepted => 1,
             BusControlAccept::NotAccepted => 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_address_unknown() {
+        let num = 0b11111111;
+
+        let flag: Address = num.into();
+        assert_eq!(flag, Address::Unknown(num));
+
+        let value: u8 = flag.into();
+        assert_eq!(value, num);
+
+        let flag: Address = value.into();
+        assert_eq!(flag, Address::Unknown(num))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// #![no_std]
+#![no_std]
 #![forbid(
     arithmetic_overflow,
     absolute_paths_not_starting_with_crate,
@@ -32,7 +32,7 @@
     unused_lifetimes,
     unused_macro_rules,
     unused_qualifications,
-    // unused_results,
+    unused_results,
     unused_tuple_struct_fields,
     variant_size_differences
 )]
@@ -49,9 +49,9 @@ pub use crate::message::{Message, MessageDirection, MessageSide, MessageType, Pa
 
 pub use crate::errors::{Error, MessageError, Result, SubsystemError, SystemError, TerminalError};
 
-pub use crate::word::{CommandWord, DataWord, StatusWord, WordType};
+pub use crate::word::{CommandWord, DataWord, StatusWord, WordType, Word};
 
 pub use crate::flags::{
-    Address, BroadcastCommand, BusControlAccept, Instrumentation, ModeCode, Reserved,
+    Address, BroadcastReceived, DynamicBusAcceptance, Instrumentation, ModeCode, Reserved,
     ServiceRequest, SubAddress, TerminalBusy, TransmitReceive,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+// #![no_std]
 #![forbid(
     arithmetic_overflow,
     absolute_paths_not_starting_with_crate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use crate::message::{Message, MessageDirection, MessageSide, MessageType, Pa
 
 pub use crate::errors::{Error, MessageError, Result, SubsystemError, SystemError, TerminalError};
 
-pub use crate::word::{CommandWord, DataWord, StatusWord, WordType, Word};
+pub use crate::word::{CommandWord, DataWord, StatusWord, Word, WordType};
 
 pub use crate::flags::{
     Address, BroadcastReceived, DynamicBusAcceptance, Instrumentation, ModeCode, Reserved,

--- a/src/message/messages.rs
+++ b/src/message/messages.rs
@@ -21,8 +21,8 @@ use crate::{errors::*, Packet, Word};
 /// # fn try_main() -> Result<()> {
 ///     let message = Message::new()
 ///         .with_command(CommandWord::new()
-///             .with_subaddress(12)
-///             .with_subaddress(5)
+///             .with_address(Address::Value(12))
+///             .with_subaddress(SubAddress::Value(5))
 ///             .with_word_count(2)
 ///             .build()?
 ///         )?
@@ -240,9 +240,7 @@ impl Message {
 
     /// Get the expected number of data words
     pub fn data_expected(&self) -> usize {
-        self.first()
-            .map(WordType::data_count)
-            .unwrap_or(0)
+        self.first().map(WordType::data_count).unwrap_or(0)
     }
 
     /// Check if message has data words
@@ -260,17 +258,13 @@ impl Message {
     /// Check if message starts with a command word
     #[must_use = "Returned value is not used"]
     pub fn has_command(&self) -> bool {
-        self.first()
-            .map(WordType::is_command)
-            .unwrap_or(false)
+        self.first().map(WordType::is_command).unwrap_or(false)
     }
 
     /// Check if message starts with a status word
     #[must_use = "Returned value is not used"]
     pub fn has_status(&self) -> bool {
-        self.first()
-            .map(WordType::is_status)
-            .unwrap_or(false)
+        self.first().map(WordType::is_status).unwrap_or(false)
     }
 
     /// Add a word to the message, returning size on success
@@ -562,9 +556,7 @@ mod tests {
             .add(CommandWord::from_value(0b0001100001100010))
             .unwrap();
 
-        message
-            .add(DataWord::from(0b0110100001101001))
-            .unwrap();
+        message.add(DataWord::from(0b0110100001101001)).unwrap();
 
         assert_eq!(message.word_count(), 2);
         assert_eq!(message.data_count(), 1);
@@ -591,9 +583,7 @@ mod tests {
             .add(StatusWord::from_value(0b0001100000000000))
             .unwrap();
 
-        message
-            .add(DataWord::from(0b0110100001101001))
-            .unwrap();
+        message.add(DataWord::from(0b0110100001101001)).unwrap();
 
         assert_eq!(message.word_count(), 2);
         assert_eq!(message.data_count(), 1);

--- a/src/message/packets.rs
+++ b/src/message/packets.rs
@@ -1,5 +1,5 @@
 use crate::errors::{parity, Error, Result};
-use crate::word::{CommandWord, DataWord, StatusWord};
+use crate::word::{CommandWord, DataWord, StatusWord, Word};
 
 /// A packet of data parsed from binary
 ///
@@ -230,7 +230,7 @@ impl Packet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flags::{Address, BroadcastCommand, SubAddress};
+    use crate::flags::{Address, BroadcastReceived, SubAddress};
 
     #[test]
     fn test_packet_parse_offset_14() {
@@ -365,7 +365,7 @@ mod tests {
         let word = packet.to_status().unwrap();
 
         assert_eq!(word.address(), Address::new(3));
-        assert_eq!(word.broadcast_received(), BroadcastCommand::Received);
+        assert_eq!(word.broadcast_received(), BroadcastReceived::Received);
     }
 
     #[test]

--- a/src/message/packets.rs
+++ b/src/message/packets.rs
@@ -106,18 +106,12 @@ impl Packet {
         buffer[2] |= bytes[2] << l;
 
         if l > 0 {
-            buffer[0] |= bytes[1]
-                .checked_shr(r)
-                .unwrap_or(0);
-            buffer[1] |= bytes[2]
-                .checked_shr(r)
-                .unwrap_or(0);
+            buffer[0] |= bytes[1].checked_shr(r).unwrap_or(0);
+            buffer[1] |= bytes[2].checked_shr(r).unwrap_or(0);
         }
 
         if l > 4 {
-            buffer[2] |= bytes[3]
-                .checked_shr(r)
-                .unwrap_or(0);
+            buffer[2] |= bytes[3].checked_shr(r).unwrap_or(0);
         }
 
         let mut sync: u8 = 0;
@@ -362,7 +356,7 @@ mod tests {
         assert_eq!(word.subaddress(), SubAddress::new(3));
 
         assert!(!word.is_mode_code());
-        assert_eq!(word.word_count(), Some(2));
+        assert_eq!(word.word_count(), 2);
     }
 
     #[test]

--- a/src/word/mod.rs
+++ b/src/word/mod.rs
@@ -4,4 +4,4 @@ mod enums;
 mod words;
 
 pub use enums::WordType;
-pub use words::{CommandWord, DataWord, StatusWord};
+pub use words::{CommandWord, DataWord, StatusWord, Word};

--- a/src/word/words.rs
+++ b/src/word/words.rs
@@ -3,7 +3,10 @@ use crate::fields::*;
 use crate::flags::*;
 
 /// Common functionality for all words
-pub trait Word where Self: Sized{
+pub trait Word
+where
+    Self: Sized,
+{
     /// Create an empty word
     fn new() -> Self;
 
@@ -35,7 +38,7 @@ pub trait Word where Self: Sized{
     fn as_value(&self) -> u16;
 
     /// Set the internal data as a slice
-    fn set_bytes(&mut self, data: [u8;2]);
+    fn set_bytes(&mut self, data: [u8; 2]);
 
     /// Set the internal data as u16
     fn set_value(&mut self, data: u16);
@@ -67,8 +70,8 @@ pub trait Word where Self: Sized{
 /// # use mil_std_1553b::*;
 /// # fn try_main() -> Result<()> {
 /// let word = CommandWord::new()
-///     .with_address(16)
-///     .with_subaddress(0) // mode code value
+///     .with_address(Address::Value(16))
+///     .with_subaddress(SubAddress::ModeCode(0))
 ///     .with_transmit_receive(TransmitReceive::Receive)
 ///     .with_mode_code(ModeCode::TransmitterShutdown)
 ///     .with_calculated_parity()
@@ -84,7 +87,7 @@ pub trait Word where Self: Sized{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandWord {
     /// Data of the word
-    data: [u8;2],
+    data: [u8; 2],
 
     /// Parity of the word
     parity: u8,
@@ -102,7 +105,7 @@ pub struct CommandWord {
 /// # use mil_std_1553b::*;
 /// # fn try_main() -> Result<()> {
 /// let word = StatusWord::new()
-///     .with_address(16)
+///     .with_address(Address::Value(16))
 ///     .with_service_request(ServiceRequest::Service)
 ///     .with_broadcast_received(BroadcastReceived::Received)
 ///     .with_calculated_parity()
@@ -118,7 +121,7 @@ pub struct CommandWord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StatusWord {
     /// Data of the word
-    data: [u8;2],
+    data: [u8; 2],
 
     /// Parity of the word
     parity: u8,
@@ -157,7 +160,6 @@ pub struct DataWord {
 }
 
 impl CommandWord {
-
     /// Get the terminal address of this word
     ///
     /// See [Address](crate::flags::Address) for more information
@@ -170,32 +172,25 @@ impl CommandWord {
     ///
     /// See [CommandWord::address] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - An [Address] to set
     ///
-    pub fn set_address<T>(&mut self, value: T)
-    where
-        T: Into<Address>,
-    {
-        let field = value.into();
-        COMMAND_ADDRESS_FIELD.set(self, field.into());
+    pub fn set_address(&mut self, value: Address) {
+        COMMAND_ADDRESS_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the terminal address
     ///
     /// See [CommandWord::address] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - An [Address] to set
     ///
-    pub fn with_address<T>(mut self, value: T) -> Self
-    where
-        T: Into<Address>,
-    {
+    pub fn with_address(mut self, value: Address) -> Self {
         self.set_address(value);
         self
     }
@@ -215,32 +210,25 @@ impl CommandWord {
     ///
     /// See [CommandWord::subaddress] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [SubAddress] to set
     ///
-    pub fn set_subaddress<T>(&mut self, value: T)
-    where
-        T: Into<SubAddress>,
-    {
-        let field = value.into();
-        COMMAND_SUBADDRESS_FIELD.set(self, field.into());
+    pub fn set_subaddress(&mut self, value: SubAddress) {
+        COMMAND_SUBADDRESS_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the subaddress
     ///
     /// See [CommandWord::subaddress] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [SubAddress] to set
     ///
-    pub fn with_subaddress<T>(mut self, value: T) -> Self
-    where
-        T: Into<SubAddress>,
-    {
+    pub fn with_subaddress(mut self, value: SubAddress) -> Self {
         self.set_subaddress(value);
         self
     }
@@ -257,32 +245,25 @@ impl CommandWord {
     ///
     /// See [TransmitReceive](crate::flags::TransmitReceive) enum for
     /// more information about this field.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [TransmitReceive] flag to set
     ///
-    pub fn set_transmit_receive<T>(&mut self, value: T)
-    where
-        T: Into<TransmitReceive>,
-    {
-        let field = value.into();
-        COMMAND_TRANSMIT_RECEIVE_FIELD.set(self, field.into());
+    pub fn set_transmit_receive(&mut self, value: TransmitReceive) {
+        COMMAND_TRANSMIT_RECEIVE_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the direction of transmission
     ///
     /// See [TransmitReceive](crate::flags::TransmitReceive) enum for
     /// more information about this field.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [TransmitReceive] flag to set
     ///
-    pub fn with_transmit_receive<T>(mut self, value: T) -> Self
-    where
-        T: Into<TransmitReceive>,
-    {
+    pub fn with_transmit_receive(mut self, value: TransmitReceive) -> Self {
         self.set_transmit_receive(value);
         self
     }
@@ -302,17 +283,13 @@ impl CommandWord {
     /// This method sets the same bits that are used by the word count field.
     /// In order to be valid, users must also set the subaddress to a valid
     /// mode code value. See [CommandWord::mode_code] for more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [ModeCode] flag to set
     ///
-    pub fn set_mode_code<T>(&mut self, value: T)
-    where
-        T: Into<ModeCode>,
-    {
-        let field = value.into();
-        COMMAND_MODE_CODE_FIELD.set(self, field.into());
+    pub fn set_mode_code(&mut self, value: ModeCode) {
+        COMMAND_MODE_CODE_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the mode code
@@ -320,15 +297,12 @@ impl CommandWord {
     /// This method sets the same bits that are used by the word count field.
     /// In order to be valid, users must also set the subaddress to a valid
     /// mode code value. See [CommandWord::mode_code] for more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [ModeCode] flag to set
     ///
-    pub fn with_mode_code<T>(mut self, value: T) -> Self
-    where
-        T: Into<ModeCode>,
-    {
+    pub fn with_mode_code(mut self, value: ModeCode) -> Self {
         self.set_mode_code(value);
         self
     }
@@ -349,7 +323,7 @@ impl CommandWord {
     ///
     /// This method will do nothing if the subaddress is set to the ModeCode
     /// value. See [CommandWord::word_count] for more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A word count to set
@@ -362,7 +336,7 @@ impl CommandWord {
     ///
     /// This method will do nothing if the subaddress is set to the ModeCode
     /// value. See [CommandWord::word_count] for more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A word count to set
@@ -407,7 +381,6 @@ impl CommandWord {
 }
 
 impl StatusWord {
-
     /// Get the terminal address of this word
     ///
     /// See [Address](crate::flags::Address) for more information
@@ -420,32 +393,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::address] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - An [Address] to set
     ///
-    pub fn set_address<T>(&mut self, value: T)
-    where
-        T: Into<Address>,
-    {
-        let field = value.into();
-        STATUS_ADDRESS_FIELD.set(self, field.into());
+    pub fn set_address(&mut self, value: Address) {
+        STATUS_ADDRESS_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the terminal address
     ///
     /// See [StatusWord::address] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - An [Address] to set
     ///
-    pub fn with_address<T>(mut self, value: T) -> Self
-    where
-        T: Into<Address>,
-    {
+    pub fn with_address(mut self, value: Address) -> Self {
         self.set_address(value);
         self
     }
@@ -465,32 +431,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::instrumentation] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - An [Instrumentation] flag to set
     ///
-    pub fn set_instrumentation<T>(&mut self, value: T)
-    where
-        T: Into<Instrumentation>,
-    {
-        let field = value.into();
-        STATUS_INSTRUMENTATION_FIELD.set(self, field.into());
+    pub fn set_instrumentation(&mut self, value: Instrumentation) {
+        STATUS_INSTRUMENTATION_FIELD.set(self, value.into());
     }
 
     /// Constructor metho to set Instrumentation flag
     ///
     /// See [StatusWord::instrumentation] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - An [Instrumentation] flag to set
     ///
-    pub fn with_instrumentation<T>(mut self, value: T) -> Self
-    where
-        T: Into<Instrumentation>,
-    {
+    pub fn with_instrumentation(mut self, value: Instrumentation) -> Self {
         self.set_instrumentation(value);
         self
     }
@@ -507,32 +466,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::service_request] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [ServiceRequest] flag to set
     ///
-    pub fn set_service_request<T>(&mut self, value: T)
-    where
-        T: Into<ServiceRequest>,
-    {
-        let field = value.into();
-        STATUS_SERVICE_REQUEST_FIELD.set(self, field.into());
+    pub fn set_service_request(&mut self, value: ServiceRequest) {
+        STATUS_SERVICE_REQUEST_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the Service Request flag
     ///
     /// See [StatusWord::service_request] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [ServiceRequest] flag to set
     ///
-    pub fn with_service_request<T>(mut self, value: T) -> Self
-    where
-        T: Into<ServiceRequest>,
-    {
+    pub fn with_service_request(mut self, value: ServiceRequest) -> Self {
         self.set_service_request(value);
         self
     }
@@ -549,32 +501,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::reserved] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [Reserved] value to set
     ///
-    pub fn set_reserved<T>(&mut self, value: T)
-    where
-        T: Into<Reserved>,
-    {
-        let field = value.into();
-        STATUS_RESERVED_FIELD.set(self, field.into());
+    pub fn set_reserved(&mut self, value: Reserved) {
+        STATUS_RESERVED_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the value of the reserved field
     ///
     /// See [StatusWord::reserved] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [Reserved] value to set
     ///
-    pub fn with_reserved<T>(mut self, value: T) -> Self
-    where
-        T: Into<Reserved>,
-    {
+    pub fn with_reserved(mut self, value: Reserved) -> Self {
         self.set_reserved(value);
         self
     }
@@ -592,32 +537,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::broadcast_received] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [BroadcastReceived] flag to set
     ///
-    pub fn set_broadcast_received<T>(&mut self, value: T)
-    where
-        T: Into<BroadcastReceived>,
-    {
-        let field = value.into();
-        STATUS_BROADCAST_RECEIVED_FIELD.set(self, field.into());
+    pub fn set_broadcast_received(&mut self, value: BroadcastReceived) {
+        STATUS_BROADCAST_RECEIVED_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the Broadcast Command flag
     ///
     /// See [StatusWord::broadcast_received] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [BroadcastReceived] flag to set
     ///
-    pub fn with_broadcast_received<T>(mut self, value: T) -> Self
-    where
-        T: Into<BroadcastReceived>,
-    {
+    pub fn with_broadcast_received(mut self, value: BroadcastReceived) -> Self {
         self.set_broadcast_received(value);
         self
     }
@@ -635,32 +573,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::terminal_busy] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [TerminalBusy] flag to set
     ///
-    pub fn set_terminal_busy<T>(&mut self, value: T)
-    where
-        T: Into<TerminalBusy>,
-    {
-        let field = value.into();
-        STATUS_TERMINAL_BUSY_FIELD.set(self, field.into());
+    pub fn set_terminal_busy(&mut self, value: TerminalBusy) {
+        STATUS_TERMINAL_BUSY_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the Busy flag
     ///
     /// See [StatusWord::terminal_busy] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [TerminalBusy] flag to set
     ///
-    pub fn with_terminal_busy<T>(mut self, value: T) -> Self
-    where
-        T: Into<TerminalBusy>,
-    {
+    pub fn with_terminal_busy(mut self, value: TerminalBusy) -> Self {
         self.set_terminal_busy(value);
         self
     }
@@ -678,32 +609,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::dynamic_bus_acceptance] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [DynamicBusAcceptance] flag to set
     ///
-    pub fn set_dynamic_bus_acceptance<T>(&mut self, value: T)
-    where
-        T: Into<DynamicBusAcceptance>,
-    {
-        let field = value.into();
-        STATUS_DYNAMIC_BUS_ACCEPTANCE_FIELD.set(self, field.into());
+    pub fn set_dynamic_bus_acceptance(&mut self, value: DynamicBusAcceptance) {
+        STATUS_DYNAMIC_BUS_ACCEPTANCE_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the Dynamic Bus Control Acceptance flag
     ///
     /// See [StatusWord::dynamic_bus_acceptance] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [DynamicBusAcceptance] flag to set
     ///
-    pub fn with_dynamic_bus_acceptance<T>(mut self, value: T) -> Self
-    where
-        T: Into<DynamicBusAcceptance>,
-    {
+    pub fn with_dynamic_bus_acceptance(mut self, value: DynamicBusAcceptance) -> Self {
         self.set_dynamic_bus_acceptance(value);
         self
     }
@@ -720,32 +644,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::message_error] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [MessageError] flag to set
     ///
-    pub fn set_message_error<T>(&mut self, value: T)
-    where
-        T: Into<MessageError>,
-    {
-        let field = value.into();
-        STATUS_MESSAGE_ERROR_FIELD.set(self, field.into());
+    pub fn set_message_error(&mut self, value: MessageError) {
+        STATUS_MESSAGE_ERROR_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the message error flag
     ///
     /// See [StatusWord::message_error] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [MessageError] flag to set
     ///
-    pub fn with_message_error<T>(mut self, value: T) -> Self
-    where
-        T: Into<MessageError>,
-    {
+    pub fn with_message_error(mut self, value: MessageError) -> Self {
         self.set_message_error(value);
         self
     }
@@ -762,32 +679,25 @@ impl StatusWord {
     ///
     /// See [StatusWord::subsystem_error] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [SubsystemError] flag to set
     ///
-    pub fn set_subsystem_error<T>(&mut self, value: T)
-    where
-        T: Into<SubsystemError>,
-    {
-        let field = value.into();
-        STATUS_SUBSYSTEM_ERROR_FIELD.set(self, field.into());
+    pub fn set_subsystem_error(&mut self, value: SubsystemError) {
+        STATUS_SUBSYSTEM_ERROR_FIELD.set(self, value.into());
     }
 
     /// Constructor method to set the subsystem error flag
     ///
     /// See [StatusWord::subsystem_error] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [SubsystemError] flag to set
     ///
-    pub fn with_subsystem_error<T>(mut self, value: T) -> Self
-    where
-        T: Into<SubsystemError>,
-    {
+    pub fn with_subsystem_error(mut self, value: SubsystemError) -> Self {
         self.set_subsystem_error(value);
         self
     }
@@ -804,32 +714,25 @@ impl StatusWord {
     ///
     /// See [`StatusWord::terminal_error`][StatusWord::terminal_error] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [TerminalError] flag to set
     ///
-    pub fn set_terminal_error<T>(&mut self, value: T)
-    where
-        T: Into<TerminalError>,
-    {
-        let field = value.into();
-        STATUS_TERMINAL_ERROR_FIELD.set(self, field.into());
+    pub fn set_terminal_error(&mut self, value: TerminalError) {
+        STATUS_TERMINAL_ERROR_FIELD.set(self, value.into());
     }
 
     /// Constructor set the terminal error flag
     ///
     /// See [`StatusWord::terminal_error`][StatusWord::terminal_error] for
     /// more information.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `value` - A [TerminalError] flag to set
     ///
-    pub fn with_terminal_error<T>(mut self, value: T) -> Self
-    where
-        T: Into<TerminalError>,
-    {
+    pub fn with_terminal_error(mut self, value: TerminalError) -> Self {
         self.set_terminal_error(value);
         self
     }
@@ -853,16 +756,14 @@ impl StatusWord {
     pub fn is_busy(&self) -> bool {
         self.terminal_busy().is_busy()
     }
-
 }
 
 impl DataWord {
-
     /// Constructor method to set the word from a string
     ///
-    /// Fails if the given string is more than two 
+    /// Fails if the given string is more than two
     /// bytes long.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `data` - A &str to set as data
@@ -874,9 +775,9 @@ impl DataWord {
 
     /// Set the word from a string
     ///
-    /// Fails if the given string is more than two 
+    /// Fails if the given string is more than two
     /// bytes long.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `data` - A &str to set as data
@@ -892,11 +793,9 @@ impl DataWord {
     pub fn as_string(&self) -> Result<&str> {
         self.try_into()
     }
-
 }
 
 impl Word for CommandWord {
-
     fn new() -> Self {
         Self {
             data: [0, 0],
@@ -933,9 +832,7 @@ impl Word for CommandWord {
     }
 
     fn from_value(data: u16) -> Self {
-        Self::new()
-            .with_value(data)
-            .with_calculated_parity()
+        Self::new().with_value(data).with_calculated_parity()
     }
 
     fn from_bytes(data: [u8; 2]) -> Self {
@@ -950,12 +847,12 @@ impl Word for CommandWord {
         self.into()
     }
 
-    fn set_value(&mut self, data: u16){
+    fn set_value(&mut self, data: u16) {
         self.data = data.to_be_bytes();
         self.parity = self.calculate_parity();
     }
 
-    fn set_bytes(&mut self, data: [u8; 2]){
+    fn set_bytes(&mut self, data: [u8; 2]) {
         self.data = data;
         self.parity = self.calculate_parity();
     }
@@ -982,7 +879,6 @@ impl Word for CommandWord {
 }
 
 impl Word for StatusWord {
-
     fn new() -> Self {
         Self {
             data: [0, 0],
@@ -1034,12 +930,12 @@ impl Word for StatusWord {
         self.into()
     }
 
-    fn set_value(&mut self, data: u16){
+    fn set_value(&mut self, data: u16) {
         self.data = data.to_be_bytes();
         self.parity = self.calculate_parity();
     }
 
-    fn set_bytes(&mut self, data: [u8; 2]){
+    fn set_bytes(&mut self, data: [u8; 2]) {
         self.data = data;
         self.parity = self.calculate_parity();
     }
@@ -1066,7 +962,6 @@ impl Word for StatusWord {
 }
 
 impl Word for DataWord {
-
     fn new() -> Self {
         Self {
             data: [0, 0],
@@ -1118,12 +1013,12 @@ impl Word for DataWord {
         self.into()
     }
 
-    fn set_value(&mut self, data: u16){
+    fn set_value(&mut self, data: u16) {
         self.data = data.to_be_bytes();
         self.parity = self.calculate_parity();
     }
 
-    fn set_bytes(&mut self, data: [u8; 2]){
+    fn set_bytes(&mut self, data: [u8; 2]) {
         self.data = data;
         self.parity = self.calculate_parity();
     }
@@ -1181,8 +1076,7 @@ impl<'a> TryFrom<&'a DataWord> for &'a str {
     type Error = Error;
 
     fn try_from(value: &'a DataWord) -> Result<Self> {
-        core::str::from_utf8(&value.data)
-            .or(Err(Error::StringIsInvalid))
+        core::str::from_utf8(&value.data).or(Err(Error::StringIsInvalid))
     }
 }
 
@@ -1204,20 +1098,20 @@ impl From<u16> for DataWord {
     }
 }
 
-impl From<[u8;2]> for CommandWord {
-    fn from(value: [u8;2]) -> Self {
+impl From<[u8; 2]> for CommandWord {
+    fn from(value: [u8; 2]) -> Self {
         Self::from_bytes(value)
     }
 }
 
-impl From<[u8;2]> for StatusWord {
-    fn from(value: [u8;2]) -> Self {
+impl From<[u8; 2]> for StatusWord {
+    fn from(value: [u8; 2]) -> Self {
         Self::from_bytes(value)
     }
 }
 
-impl From<[u8;2]> for DataWord {
-    fn from(value: [u8;2]) -> Self {
+impl From<[u8; 2]> for DataWord {
+    fn from(value: [u8; 2]) -> Self {
         Self::from_bytes(value)
     }
 }
@@ -1406,11 +1300,11 @@ mod tests {
     #[test]
     fn test_status_with_methods() {
         let word = StatusWord::new()
-            .with_address(4)
-            .with_terminal_busy(1)
-            .with_message_error(1)
-            .with_terminal_error(1)
-            .with_subsystem_error(1)
+            .with_address(Address::Value(4))
+            .with_terminal_busy(TerminalBusy::Busy)
+            .with_message_error(MessageError::Error)
+            .with_terminal_error(TerminalError::Error)
+            .with_subsystem_error(SubsystemError::Error)
             .build()
             .unwrap();
 
@@ -1424,9 +1318,9 @@ mod tests {
     #[test]
     fn test_command_with_methods() {
         let word = CommandWord::new()
-            .with_address(4)
-            .with_subaddress(2)
-            .with_transmit_receive(1)
+            .with_address(Address::Value(4))
+            .with_subaddress(SubAddress::Value(2))
+            .with_transmit_receive(TransmitReceive::Transmit)
             .with_word_count(3)
             .build()
             .unwrap();
@@ -1443,7 +1337,7 @@ mod tests {
         let mut word = CommandWord::from_value(0b0000000000101010);
         assert_eq!(word.parity, 0);
 
-        word.set_address(0b00000001);
+        word.set_address(Address::Value(0b00000001));
         assert_eq!(word.parity, 1);
     }
 
@@ -1452,7 +1346,7 @@ mod tests {
         let mut word = StatusWord::from_value(0b0000000010101010);
         assert_eq!(word.parity, 1);
 
-        word.set_address(0b00000001);
+        word.set_address(Address::Value(0b00000001));
         assert_eq!(word.parity, 0);
     }
 
@@ -1496,39 +1390,39 @@ mod tests {
 
     #[test]
     fn test_command_get_address() {
-        let word = CommandWord::new().with_address(0b11111);
+        let word = CommandWord::new().with_address(Address::Value(0b11111));
         assert!(word.address().is_broadcast());
     }
 
     #[test]
     fn test_command_set_address() {
         let mut word = CommandWord::new();
-        word.set_address(0b10101);
+        word.set_address(Address::Value(0b10101));
         assert_eq!(word.as_value(), 0b1010100000000000);
     }
 
     #[test]
     fn test_command_set_broadcast_address() {
-        let word = CommandWord::new().with_address(0b11111);
+        let word = CommandWord::new().with_address(Address::Value(0b11111));
         assert!(word.address().is_broadcast());
     }
 
     #[test]
     fn test_command_get_subaddress_ones() {
-        let word = CommandWord::new().with_subaddress(0b11111);
+        let word = CommandWord::new().with_subaddress(SubAddress::Value(0b11111));
         assert!(word.subaddress().is_mode_code());
     }
 
     #[test]
     fn test_command_get_subaddress_zeroes() {
-        let word = CommandWord::new().with_subaddress(0b00000);
+        let word = CommandWord::new().with_subaddress(SubAddress::Value(0b00000));
         assert!(word.subaddress().is_mode_code());
     }
 
     #[test]
     fn test_command_set_subaddress() {
         let mut word = CommandWord::new();
-        word.set_subaddress(0b10101);
+        word.set_subaddress(SubAddress::Value(0b10101));
         assert_eq!(word.as_value(), 0b0000001010100000);
     }
 
@@ -1564,7 +1458,7 @@ mod tests {
         let mut word = CommandWord::new();
         assert!(word.is_mode_code());
 
-        word.set_subaddress(0b01010);
+        word.set_subaddress(SubAddress::Value(0b01010));
         assert!(!word.is_mode_code());
     }
 
@@ -1588,7 +1482,7 @@ mod tests {
 
     #[test]
     fn test_status_get_address() {
-        let word = StatusWord::new().with_address(0b11111);
+        let word = StatusWord::new().with_address(Address::Value(0b11111));
         assert!(word.address().is_broadcast());
     }
 
@@ -1597,10 +1491,10 @@ mod tests {
         let mut word = StatusWord::new();
         assert_eq!(word.address(), Address::Value(0));
 
-        word.set_address(0b10101);
+        word.set_address(Address::Value(0b10101));
         assert_eq!(word.address(), Address::Value(0b10101));
 
-        word.set_address(0b11111);
+        word.set_address(Address::Value(0b11111));
         assert_eq!(word.address(), Address::Broadcast(0b11111));
     }
 
@@ -1652,10 +1546,16 @@ mod tests {
     #[test]
     fn test_status_get_set_dynamic_bus_acceptance() {
         let mut word = StatusWord::new();
-        assert_eq!(word.dynamic_bus_acceptance(), DynamicBusAcceptance::NotAccepted);
+        assert_eq!(
+            word.dynamic_bus_acceptance(),
+            DynamicBusAcceptance::NotAccepted
+        );
 
         word.set_dynamic_bus_acceptance(DynamicBusAcceptance::Accepted);
-        assert_eq!(word.dynamic_bus_acceptance(), DynamicBusAcceptance::Accepted);
+        assert_eq!(
+            word.dynamic_bus_acceptance(),
+            DynamicBusAcceptance::Accepted
+        );
     }
 
     #[test]
@@ -1688,7 +1588,7 @@ mod tests {
     #[test]
     fn test_data_bytes() {
         let word = DataWord::from(0b0110100001101001);
-        let data: [u8;2] = word.into();
+        let data: [u8; 2] = word.into();
         assert_eq!(data, [0b01101000, 0b01101001]);
     }
 


### PR DESCRIPTION
This PR will resolve #48, #40, and #29

* Added numerous conversion trait implementations
* Removed conditional returns in word methods
* Added `Word` trait and implemented for all words to standardize interface
* Removed generics on word methods to make use more explicit
* Renamed some enums to standardize naming between enums, methods, and fields.