### PR TITLE
Change defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,14 @@ categories = [
 ]
 
 [features]
-default = [ "derive" ]
 derive = [ "dep:mil_std_1553b_derive" ]
 
 [dependencies]
 mil_std_1553b_derive = { path = "crates/mil_std_1553b_derive", optional = true }
+
+[[example]]
+name = "custom"
+required-features = [ "derive" ]
+
+[[example]]
+name = "simple"

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -47,8 +47,8 @@ fn main() {
 
     // Get words by getting the appropriate data word and mapping
     // them to our custom word.
-    let word1 = message.get_as::<CustomWord>(0);
-    let word2 = message.get_as::<CustomWord>(1);
+    let word1 = message.get::<CustomWord>(0);
+    let word2 = message.get::<CustomWord>(1);
 
     // Access the 'status light on' flag of the custom word
     let status_light_on_1 = word1.unwrap().status_light_on();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,9 +16,9 @@ fn main() -> Result<()> {
         .with_data(DataWord::try_from("Y ")?)
         .build()?;
 
-    let word0 = message.get(0).unwrap();
-    let word1 = message.get(1).unwrap();
-    let word2 = message.get(2).unwrap();
+    let word0 = message.at(0).unwrap();
+    let word1 = message.at(1).unwrap();
+    let word2 = message.at(2).unwrap();
 
     println!("{}", word0.as_string().unwrap());
     println!("{}", word1.as_string().unwrap());

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -377,7 +377,7 @@ impl SubAddress {
 impl From<u8> for SubAddress {
     fn from(v: u8) -> SubAddress {
         match v {
-            k if k < Self::MAX && k > 0 => SubAddress::Value(k),        
+            k if k < Self::MAX && k > 0 => SubAddress::Value(k),
             k => SubAddress::ModeCode(k & Self::MAX),
         }
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -304,6 +304,9 @@ pub enum Address {
 }
 
 impl Address {
+    /// The maximum real value that can be addressed
+    const MAX: u8 = 0b11111;
+
     /// Check if this enum contains an address
     #[must_use = "Returned value is not used"]
     pub const fn is_value(&self) -> bool {
@@ -320,8 +323,8 @@ impl Address {
 impl From<u8> for Address {
     fn from(v: u8) -> Address {
         match v {
-            k if k < 0b11111 => Address::Value(k),
-            k => Address::Broadcast(k),
+            k if k < Self::MAX => Address::Value(k),
+            k => Address::Broadcast(k & Self::MAX),
         }
     }
 }
@@ -355,12 +358,17 @@ pub enum SubAddress {
 }
 
 impl SubAddress {
+    /// The maximum real value that can be addressed
+    const MAX: u8 = 0b11111;
+
     /// Check if this enum contains an address
+    #[must_use = "Returned value is not used"]
     pub const fn is_value(&self) -> bool {
         matches!(self, Self::Value(_))
     }
 
     /// Check if this address is a reserved mode code value
+    #[must_use = "Returned value is not used"]
     pub const fn is_mode_code(&self) -> bool {
         matches!(self, Self::ModeCode(_))
     }
@@ -369,8 +377,8 @@ impl SubAddress {
 impl From<u8> for SubAddress {
     fn from(v: u8) -> SubAddress {
         match v {
-            k if k < 0b11111 && k > 0 => SubAddress::Value(k),        
-            k => SubAddress::ModeCode(k),
+            k if k < Self::MAX && k > 0 => SubAddress::Value(k),        
+            k => SubAddress::ModeCode(k & Self::MAX),
         }
     }
 }
@@ -427,8 +435,8 @@ impl Instrumentation {
 impl From<u8> for Instrumentation {
     fn from(value: u8) -> Self {
         match value {
-            1 => Self::Command,
-            _ => Self::Status,
+            0 => Self::Status,
+            _ => Self::Command,
         }
     }
 }
@@ -436,8 +444,8 @@ impl From<u8> for Instrumentation {
 impl From<Instrumentation> for u8 {
     fn from(value: Instrumentation) -> Self {
         match value {
-            Instrumentation::Command => 1,
             Instrumentation::Status => 0,
+            Instrumentation::Command => 1,
         }
     }
 }
@@ -481,8 +489,8 @@ impl ServiceRequest {
 impl From<u8> for ServiceRequest {
     fn from(value: u8) -> Self {
         match value {
-            1 => Self::Service,
-            _ => Self::NoService,
+            0 => Self::NoService,
+            _ => Self::Service,
         }
     }
 }
@@ -490,8 +498,8 @@ impl From<u8> for ServiceRequest {
 impl From<ServiceRequest> for u8 {
     fn from(value: ServiceRequest) -> Self {
         match value {
-            ServiceRequest::Service => 1,
             ServiceRequest::NoService => 0,
+            ServiceRequest::Service => 1,
         }
     }
 }
@@ -587,8 +595,8 @@ impl BroadcastReceived {
 impl From<u8> for BroadcastReceived {
     fn from(value: u8) -> Self {
         match value {
-            1 => Self::Received,
-            _ => Self::NotReceived,
+            0 => Self::NotReceived,
+            _ => Self::Received,
         }
     }
 }
@@ -596,8 +604,8 @@ impl From<u8> for BroadcastReceived {
 impl From<BroadcastReceived> for u8 {
     fn from(value: BroadcastReceived) -> Self {
         match value {
-            BroadcastReceived::Received => 1,
             BroadcastReceived::NotReceived => 0,
+            BroadcastReceived::Received => 1,
         }
     }
 }
@@ -640,8 +648,8 @@ impl TerminalBusy {
 impl From<u8> for TerminalBusy {
     fn from(value: u8) -> Self {
         match value {
-            1 => Self::Busy,
-            _ => Self::NotBusy,
+            0 => Self::NotBusy,
+            _ => Self::Busy,
         }
     }
 }
@@ -649,8 +657,8 @@ impl From<u8> for TerminalBusy {
 impl From<TerminalBusy> for u8 {
     fn from(value: TerminalBusy) -> Self {
         match value {
-            TerminalBusy::Busy => 1,
             TerminalBusy::NotBusy => 0,
+            TerminalBusy::Busy => 1,
         }
     }
 }
@@ -694,8 +702,8 @@ impl DynamicBusAcceptance {
 impl From<u8> for DynamicBusAcceptance {
     fn from(value: u8) -> Self {
         match value {
-            1 => Self::Accepted,
-            _ => Self::NotAccepted,
+            0 => Self::NotAccepted,
+            _ => Self::Accepted,
         }
     }
 }
@@ -703,8 +711,8 @@ impl From<u8> for DynamicBusAcceptance {
 impl From<DynamicBusAcceptance> for u8 {
     fn from(value: DynamicBusAcceptance) -> Self {
         match value {
-            DynamicBusAcceptance::Accepted => 1,
             DynamicBusAcceptance::NotAccepted => 0,
+            DynamicBusAcceptance::Accepted => 1,
         }
     }
 }
@@ -1434,6 +1442,11 @@ mod tests {
     }
 
     #[test]
+    fn test_transmit_receive_from_u8_2() {
+        assert_eq!(TransmitReceive::from(2), TransmitReceive::Transmit);
+    }
+
+    #[test]
     fn test_transmit_receive_to_u8_0() {
         assert_eq!(u8::from(TransmitReceive::Receive), 0);
     }
@@ -1488,6 +1501,11 @@ mod tests {
     #[test]
     fn test_address_from_u8_2() {
         assert_eq!(Address::from(0b11111), Address::Broadcast(0b11111));
+    }
+
+    #[test]
+    fn test_address_from_u8_3() {
+        assert_eq!(Address::from(0b11111111), Address::Broadcast(0b11111));
     }
 
     #[test]
@@ -1549,12 +1567,17 @@ mod tests {
 
     #[test]
     fn test_subaddress_from_u8_2() {
-        assert_eq!(SubAddress::from(0b11111), SubAddress::ModeCode(0b11111));
+        assert_eq!(SubAddress::from(0b00000), SubAddress::ModeCode(0b00000));
     }
 
     #[test]
     fn test_subaddress_from_u8_3() {
-        assert_eq!(SubAddress::from(0b00000), SubAddress::ModeCode(0b00000));
+        assert_eq!(SubAddress::from(0b11111), SubAddress::ModeCode(0b11111));
+    }
+
+    #[test]
+    fn test_subaddress_from_u8_4() {
+        assert_eq!(SubAddress::from(0b11111111), SubAddress::ModeCode(0b11111));
     }
 
     #[test]
@@ -1592,6 +1615,11 @@ mod tests {
     #[test]
     fn test_instrumentation_from_u8_1() {
         assert_eq!(Instrumentation::from(1), Instrumentation::Command);
+    }
+
+    #[test]
+    fn test_instrumentation_from_u8_2() {
+        assert_eq!(Instrumentation::from(2), Instrumentation::Command);
     }
 
     #[test]
@@ -1639,6 +1667,11 @@ mod tests {
     #[test]
     fn test_service_request_from_u8_1() {
         assert_eq!(ServiceRequest::from(1), ServiceRequest::Service);
+    }
+
+    #[test]
+    fn test_service_request_from_u8_2() {
+        assert_eq!(ServiceRequest::from(2), ServiceRequest::Service);
     }
 
     #[test]
@@ -1736,6 +1769,11 @@ mod tests {
     }
 
     #[test]
+    fn test_broadcast_received_from_u8_2() {
+        assert_eq!(BroadcastReceived::from(2), BroadcastReceived::Received);
+    }
+
+    #[test]
     fn test_broadcast_received_to_u8_0() {
         assert_eq!(u8::from(BroadcastReceived::NotReceived), 0);
     }
@@ -1780,6 +1818,11 @@ mod tests {
     #[test]
     fn test_terminal_busy_from_u8_1() {
         assert_eq!(TerminalBusy::from(1), TerminalBusy::Busy);
+    }
+
+    #[test]
+    fn test_terminal_busy_from_u8_2() {
+        assert_eq!(TerminalBusy::from(2), TerminalBusy::Busy);
     }
 
     #[test]
@@ -1831,6 +1874,14 @@ mod tests {
     fn test_dynamic_bus_acceptance_from_u8_1() {
         assert_eq!(
             DynamicBusAcceptance::from(1),
+            DynamicBusAcceptance::Accepted
+        );
+    }
+
+    #[test]
+    fn test_dynamic_bus_acceptance_from_u8_2() {
+        assert_eq!(
+            DynamicBusAcceptance::from(2),
             DynamicBusAcceptance::Accepted
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ mod flags;
 mod message;
 mod word;
 
+#[cfg(feature = "derive")]
 pub use mil_std_1553b_derive as derive;
 
 pub use crate::fields::Field;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![forbid(
+    dead_code,
     arithmetic_overflow,
     absolute_paths_not_starting_with_crate,
     box_pointers,
@@ -33,7 +34,6 @@
     unused_macro_rules,
     unused_qualifications,
     unused_results,
-    unused_tuple_struct_fields,
     variant_size_differences
 )]
 #![doc = include_str!("../README.md")]

--- a/src/message/messages.rs
+++ b/src/message/messages.rs
@@ -260,7 +260,7 @@ impl<const WORDS: usize> Message<WORDS> {
     ///
     /// * `index` - An index
     ///
-    pub fn get(&self, index: usize) -> Option<DataWord> {
+    pub fn at(&self, index: usize) -> Option<DataWord> {
         if let Some(WordType::Data(w)) = &self.words.get(index + 1) {
             Some(*w)
         } else {
@@ -277,7 +277,7 @@ impl<const WORDS: usize> Message<WORDS> {
     ///
     /// * `index` - An index
     ///
-    pub fn get_as<T>(&self, index: usize) -> Option<T>
+    pub fn get<T>(&self, index: usize) -> Option<T>
     where
         T: From<DataWord>,
     {
@@ -507,6 +507,7 @@ mod tests {
             .with_data(0b0000000000000001)
             .build()
             .unwrap();
+        assert!(message.is_full());
         assert_eq!(message.length(), 2);
         assert_eq!(message.count(), 1);
         assert_eq!(message.size(), 2);
@@ -558,6 +559,7 @@ mod tests {
             .with_data(0b0000000000000001)
             .build()
             .unwrap();
+        assert!(message.is_full());
         assert_eq!(message.length(), 2);
         assert_eq!(message.count(), 1);
         assert_eq!(message.size(), 2);
@@ -788,7 +790,7 @@ mod tests {
     }
 
     #[test]
-    fn test_message_get() {
+    fn test_message_at() {
         let data1: DataWord = 0b0000000000000101.into();
         let data2: DataWord = 0b0000000000010101.into();
         let data3: DataWord = 0b0000000001010101.into();
@@ -801,10 +803,35 @@ mod tests {
             .build()
             .unwrap();
 
-        let word1 = message.get(0);
-        let word2 = message.get(1);
-        let word3 = message.get(2);
-        let word4 = message.get(3);
+        let word1 = message.at(0);
+        let word2 = message.at(1);
+        let word3 = message.at(2);
+        let word4 = message.at(3);
+
+        assert_eq!(word1, Some(data1));
+        assert_eq!(word2, Some(data2));
+        assert_eq!(word3, Some(data3));
+        assert_eq!(word4, None);
+    }
+
+    #[test]
+    fn test_message_get() {
+        let data1: u16 = 0b0000000000000101;
+        let data2: u16 = 0b0000000000010101;
+        let data3: u16 = 0b0000000001010101;
+
+        let message = Message::<4>::new()
+            .with_command(0b0000000000000011)
+            .with_data(data1)
+            .with_data(data2)
+            .with_data(data3)
+            .build()
+            .unwrap();
+
+        let word1 = message.get::<u16>(0);
+        let word2 = message.get::<u16>(1);
+        let word3 = message.get::<u16>(2);
+        let word4 = message.get::<u16>(3);
 
         assert_eq!(word1, Some(data1));
         assert_eq!(word2, Some(data2));

--- a/src/word/words.rs
+++ b/src/word/words.rs
@@ -1140,7 +1140,7 @@ impl From<&DataWord> for u16 {
 
 impl From<DataWord> for u16 {
     fn from(value: DataWord) -> Self {
-        u16::from_be_bytes(value.data)
+        u16::from(&value)
     }
 }
 
@@ -1152,7 +1152,7 @@ impl From<&DataWord> for i16 {
 
 impl From<DataWord> for i16 {
     fn from(value: DataWord) -> Self {
-        u16::from(value) as i16
+        i16::from(&value)
     }
 }
 
@@ -1164,7 +1164,7 @@ impl From<&DataWord> for u32 {
 
 impl From<DataWord> for u32 {
     fn from(value: DataWord) -> Self {
-        u16::from(value) as u32
+        u32::from(&value)
     }
 }
 
@@ -1176,7 +1176,7 @@ impl From<&DataWord> for i32 {
 
 impl From<DataWord> for i32 {
     fn from(value: DataWord) -> Self {
-        u16::from(value) as i32
+        i32::from(&value)
     }
 }
 
@@ -1188,7 +1188,7 @@ impl From<&DataWord> for u64 {
 
 impl From<DataWord> for u64 {
     fn from(value: DataWord) -> Self {
-        u16::from(value) as u64
+        u64::from(&value)
     }
 }
 
@@ -1200,7 +1200,7 @@ impl From<&DataWord> for i64 {
 
 impl From<DataWord> for i64 {
     fn from(value: DataWord) -> Self {
-        u16::from(value) as i64
+        i64::from(&value)
     }
 }
 


### PR DESCRIPTION
This PR will close #63 and #49

## Main changes
* Changed the defaults of all flag enums to essentially truncate given values rather than default to whichever variant has a value of `0`. So parsing a u8 with a value of `0b11` into a `TransmitReceive` enum will truncate to `1`, which is the `Transmit` variant. Originally, this would have defaulted to `Receive`, which has a value of `0`.
* Removed the `Unknown` variants from `Address` and `SubAddress` because they don't serve a purpose when parsing (the value being parsed from the message will always be 5 bits wide) and make usage confusing when the addresses are constructed by users of the library.

## Other changes
* Removed `derive` as a default feature flag
* Added explicit example config in toml
* Added required feature flag `derive` for custom example
* Changed `get` to `at`
* Changed `get_as` to `get`
* Changed old `unused_tuple_struct_fields` lint to `dead_code`
* Updated examples to accommodate changes
* Improved code coverage
* Added a few missing `must_use` declarations on `is_` methods