### PR TITLE
Added methods to set and add bytes and str

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,13 +16,13 @@ fn main() -> Result<()> {
         .with_data(DataWord::try_from("Y ")?)
         .build()?;
 
-    let word0 = message.at(0).unwrap();
-    let word1 = message.at(1).unwrap();
-    let word2 = message.at(2).unwrap();
+    let word0: &str = message.get(0).unwrap();
+    let word1: &str = message.get(1).unwrap();
+    let word2: &str = message.get(2).unwrap();
 
-    println!("{}", word0.as_string().unwrap());
-    println!("{}", word1.as_string().unwrap());
-    println!("{}", word2.as_string().unwrap());
+    println!("{}", word0);
+    println!("{}", word1);
+    println!("{}", word2);
 
     Ok(())
 }


### PR DESCRIPTION
Should resolve #31

* Simplified get to allow conversion into any type that implements `TryFrom<&DataWord>`. This allows us to use the method to get strings back from indexed words.
* Added `set_string` and `set_bytes` to update the message body after construction.
* Added `add_string` and `add_bytes` to append to the message body .
* Added `with_string` and `with_bytes` to parse strings and bytes into words during construction.
* Changed `at` to return a reference to be more in line with std
* Added validation check for command words to insure that all data words have been given.
* Added tests for all methods